### PR TITLE
Linux crash fixes & Configuration C++11 compliance

### DIFF
--- a/MfgToolLib/DeviceManager.cpp
+++ b/MfgToolLib/DeviceManager.cpp
@@ -903,7 +903,7 @@ int DevChange_callback(struct libusb_context *ctx, struct libusb_device *dev, li
 								}
 								while (cmdOpIndex < MAX_BOARD_NUMBERS)
 								{
-									if (((MFGLIB_VARS *)m_pLibHandle)->g_CmdOperationArray[cmdOpIndex]->m_pDevice)
+									if (((MFGLIB_VARS *)m_pLibHandle)->g_CmdOperationArray[cmdOpIndex] != nullptr && ((MFGLIB_VARS *)m_pLibHandle)->g_CmdOperationArray[cmdOpIndex]->m_pDevice)
 									{
 										bool b = !mports.CompareNoCase(((MFGLIB_VARS *)m_pLibHandle)->g_CmdOperationArray[cmdOpIndex]->m_pDevice->_hub.get());
 										if (!mports.CompareNoCase(((MFGLIB_VARS *)m_pLibHandle)->g_CmdOperationArray[cmdOpIndex]->m_pDevice->_hub.get()))

--- a/MfgToolLib/MxHidDevice.cpp
+++ b/MfgToolLib/MxHidDevice.cpp
@@ -1069,7 +1069,7 @@ BOOL MxHidDevice::RunPlugIn(UCHAR *pFileDataBuf, ULONGLONG dwFileSize)
 			BootDataImgAddrIndex = (DWORD *)pIVT2 - pPlugIn;
 			BootDataImgAddrIndex += (pIVT2->BootData - pIVT2->SelfAddr) / sizeof(DWORD);
 			PhyRAMAddr4KRL = pPlugIn[BootDataImgAddrIndex] + IVT_OFFSET - ImgIVTOffset;
-			if (!TransData(PhyRAMAddr4KRL, (unsigned int)dwFileSize, (PUCHAR)((DWORD)pDataBuf)))
+			if (!TransData(PhyRAMAddr4KRL, (unsigned int)dwFileSize, pDataBuf))
 			{
 				LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_FATAL_ERROR, _T("RunPlugIn(): TransData(0x%X, 0x%X,0x%X) failed.\n"),
 					PhyRAMAddr4KRL, dwFileSize, pDataBuf);
@@ -1094,7 +1094,7 @@ BOOL MxHidDevice::RunPlugIn(UCHAR *pFileDataBuf, ULONGLONG dwFileSize)
 		if (this->_chipFamily < MX7D)
 			pIVT->DCDAddress = 0;
 
-		if (!TransData(PhyRAMAddr4KRL, (unsigned int)dwFileSize, (PUCHAR)((DWORD)pDataBuf)))
+		if (!TransData(PhyRAMAddr4KRL, (unsigned int)dwFileSize, pDataBuf ))
 		{
 			LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_FATAL_ERROR, _T("RunPlugIn(): TransData(0x%X, 0x%X,0x%X) failed."),
 				PhyRAMAddr4KRL, dwFileSize, pDataBuf);

--- a/TestPrgm/mfgtoolCLI.cpp
+++ b/TestPrgm/mfgtoolCLI.cpp
@@ -206,10 +206,9 @@ int main (int argc,char* argv[]){
 	TERM_WIDTH = w.ws_col;
 	BAR_WIDTH = 0.8 * TERM_WIDTH;
 
-	char * newpath = "./";
-	char * mylist = "SabreSD";
-	char * myprofile = "Linux";
-
+	std::string newpath = "./";
+	std::string mylist = "SabreSD";
+	std::string myprofile = "Linux";
 
 	std::map<CString, CString> m_uclKeywords;
 	std::map<CString, CString>::const_iterator it;
@@ -234,12 +233,16 @@ int main (int argc,char* argv[]){
 				switch (state)
 				{
 					case 0:
-						myprofile = std::string(str.substr(locBreak + strip, str.size() - locBreak)).data();
+						myprofile = std::string(str.substr(locBreak + strip, str.size() - locBreak));
+						break;
 					case 1:
+						break;
 					case 2:
-						mylist = std::string(str.substr(locBreak + strip, str.size() - locBreak)).data();
+						mylist = std::string(str.substr(locBreak + strip, str.size() - locBreak));
+						break;
 					case 3:
 						m_uclKeywords[str.substr(0, locBreak)] = str.substr(locBreak + strip, str.size() - locBreak);
+						break;
 				}
 			}
 			if (str.compare("[profiles]") == 0)
@@ -355,7 +358,7 @@ int main (int argc,char* argv[]){
 	}
 
 
-	ret = MfgLib_SetProfilePath(lib, (BYTE_t *) newpath);
+	ret = MfgLib_SetProfilePath(lib, (BYTE_t *) newpath.c_str());
 	if(ret != MFGLIB_ERROR_SUCCESS)
 	{
 		printf(_T("Set Profile path failed\n"));
@@ -363,13 +366,13 @@ int main (int argc,char* argv[]){
 	}
 
 	//set profile and list
-	ret = MfgLib_SetProfileName(lib,(BYTE_t *) myprofile);
+	ret = MfgLib_SetProfileName(lib,(BYTE_t *) myprofile.c_str());
 	if(ret != MFGLIB_ERROR_SUCCESS)
 	{
 		printf(_T("Set Profile name failed\n"));
 		return -1;
 	}
-	ret = MfgLib_SetListName(lib, (BYTE_t *) mylist);
+	ret = MfgLib_SetListName(lib, (BYTE_t *) mylist.c_str());
 	if(ret != MFGLIB_ERROR_SUCCESS)
 	{
 		printf(_T("Set List name failed\n"));


### PR DESCRIPTION
This commit fixes two crashes due to bad pointers, and makes the configuration parser work with C++11 compatible compilers.