### PR TITLE
Fixed CMAKE relative path error

### DIFF
--- a/uuu/CMakeLists.txt
+++ b/uuu/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SOURCES
 	uuu.clst
 )
 
-link_directories(../libuuu)
+link_directories(${CMAKE_CURRENT_SOURCE_DIR}/libuuu)
 
 add_custom_command(
         OUTPUT uuu.clst


### PR DESCRIPTION
Fixed the following CMAKE error:

CMake Warning (dev) at uuu/CMakeLists.txt:16 (link_directories):
  This command specifies the relative path

    ../libuuu

  as a link directory.

  Policy CMP0015 is not set: link_directories() treats paths relative to the
  source dir.  Run "cmake --help-policy CMP0015" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.