### PR TITLE
Add the possibility to specify parameters specific per hub/port

### DIFF
--- a/Apps/MfgToolLib/MfgToolLib.def
+++ b/Apps/MfgToolLib/MfgToolLib.def
@@ -23,3 +23,4 @@ EXPORTS
     MfgLib_CreateInstanceHandle          @17
     MfgLib_DestoryInstanceHandle         @18
     MfgLib_SetUCLKeyWord                 @19
+    MfgLib_SetUsbPortKeyWord             @20

--- a/Apps/MfgToolLib/MfgToolLib.h
+++ b/Apps/MfgToolLib/MfgToolLib.h
@@ -423,6 +423,9 @@ DWORD GetCurrentDeviceDesc(MFGLIB_VARS *pLibVars, int DeviceIndex, TCHAR* desc, 
 BOOL FindLibraryHandle(MFGLIB_VARS *pLibVars);
 int FindOperationIndex(MFGLIB_VARS *pLibVars, DWORD operationID);
 CString ReplaceKeywords(CString str);
+CString ReplaceUsbPortKeywords(CString str, UINT hub, UINT port);
+void ReplaceAllUsbPortKeyWords(MFGLIB_VARS *pLibVars, int WndIndex);
+
 
 
 

--- a/Apps/MfgToolLib/MfgToolLib_Export.h
+++ b/Apps/MfgToolLib/MfgToolLib_Export.h
@@ -228,6 +228,7 @@ DWORD MfgLib_RegisterCallbackFunction(INSTANCE_HANDLE handle, CALLBACK_TYPE cbTy
 DWORD MfgLib_UnregisterCallbackFunction(INSTANCE_HANDLE handle, CALLBACK_TYPE cbType, void *pFunc);
 DWORD MfgLib_GetLibraryVersion(BYTE_t* version, int maxSize);
 DWORD MfgLib_SetUCLKeyWord(CHAR_t *key, CHAR_t *value);
+DWORD MfgLib_SetUsbPortKeyWord(UINT hub, UINT index, CHAR_t *key, CHAR_t *value);
 
 
 

--- a/Apps/MfgTool_MultiPanel/MfgTool_MultiPanel.h
+++ b/Apps/MfgTool_MultiPanel/MfgTool_MultiPanel.h
@@ -39,6 +39,7 @@
 #include "PortMgr.h"
 #include "../MfgToolLib/MfgToolLib_Export.h"
 #include <map>
+#include <tuple>
 
 // CMfgTool_MultiPanelApp:
 // See MfgTool_MultiPanel.cpp for the implementation of this class
@@ -69,6 +70,9 @@ public:
 	CString m_strProfileName;
 	CString m_strListName;
 	std::map<CString, CString> m_uclKeywords;
+	// For usb-port specific parameters, we use as key a tuple <hub, index, parameter name>
+	typedef std::tuple<UINT, UINT, CString> UsbPortKey;
+	std::map<UsbPortKey, CString> m_usbPortKeywords;
 	BOOL m_IsAutoStart;
 	BOOL ParseCfgFile(CString strFilename, BOOL bMsgBox);
 	BOOL IsSectionExist(CString strSection, CString strFilename);


### PR DESCRIPTION
Add the possibility to specify via command line a parameter specific for
a given hub-port combination in the format
    -u parameterName[hub index][port index]

(whereas the already present option -s apply the same extra parameters
to all devices).

For example if we want to flash 4 mac address, each one different for any
device we can specify something like this:

 mfgtool2.exe -p 4 -c "linux" -l ""eMMC"" -s "mmc=0" -u
 mac[1][1]="AB:CD:EF:12:34:56" -u mac[1][2]="12:23:34:AA:BB:CC" -u
 mac[2][1]="AA:BB:CC:DD:EE:FF" -u mac[3][1]= "11:22:33:44:55:66"

Then in ucl2.xml we can just use %parameter% (%mac% in our example
above) to reference a specific parameter, and depending on the hub -
port indexes, the proper substition will be taken in place e.g. if the
device is inserted in hub =2, port =1 we will replace %mac% with
"AA:BB:CC:DD:EE:FF".