### PR TITLE
avoid warning

### DIFF
--- a/uuu/uuu.cpp
+++ b/uuu/uuu.cpp
@@ -525,7 +525,7 @@ int get_console_width()
 }
 #else
 #include <sys/ioctl.h>
-bool enable_vt_mode() {}
+bool enable_vt_mode() { return true; }
 int get_console_width()
 {
 	struct winsize w;


### PR DESCRIPTION
Avoid warning when using GCC:
  warning: no return statement in function returning non-void

Signed-off-by: Stefan Agner <stefan@agner.ch>