### PR TITLE
uuu: fix build on openSUSE tumbleweed

### DIFF
--- a/uuu/CMakeLists.txt
+++ b/uuu/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required (VERSION 2.6)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBUSB REQUIRED libusb-1.0>=1.0.16)
 pkg_check_modules(LIBZIP REQUIRED libzip)
+pkg_check_modules(LIBZ REQUIRED zlib)
 find_package(Threads)
 
 set(CMAKE_CXX_FLAGS "-std=c++11 -pthread -static-libstdc++ -static-libgcc")
@@ -22,4 +23,4 @@ add_custom_command(
 )
 
 add_executable(uuu ${SOURCES})
-target_link_libraries(uuu uuc_s  ${LIBUSB_LIBRARIES} ${LIBZIP_LIBRARIES})
+target_link_libraries(uuu uuc_s  ${LIBUSB_LIBRARIES} ${LIBZIP_LIBRARIES} ${LIBZ_LIBRARIES})


### PR DESCRIPTION
Met error on openSUSE tumbleweed:
[ 93%] Linking CXX executable uuu
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld:
../libuuu/libuuc_s.a(zip.cpp.o): undefined reference to symbol 'inflateEnd'
/lib64/libz.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [uuu/CMakeFiles/uuu.dir/build.make:100: uuu/uuu] Error 1
make[1]: *** [CMakeFiles/Makefile2:180: uuu/CMakeFiles/uuu.dir/all] Error 2

Need to add libz.

Signed-off-by: Peng Fan <peng.fan@nxp.com>