### PR TITLE
Add timeout management for each command in console mode

### DIFF
--- a/Apps/MfgToolLib/CmdOperation.cpp
+++ b/Apps/MfgToolLib/CmdOperation.cpp
@@ -551,7 +551,7 @@ UINT CmdListThreadProc(LPVOID pParam)
 				COpCommand *pCmd = (*cmdIt);
 				if(pCmd->IsRun(chip) && pCmd->IsRun(habstate))
 				{
-					dwError = pCmd->ExecuteCommand(pOperation->m_WndIndex);
+					dwError = pCmd->ExecuteCommandWithTimeout(pOperation->m_WndIndex, COpCommand::GetCommandTimeout());
 				}else
 				{
 					dwError = MFGLIB_ERROR_SKIP;

--- a/Apps/MfgToolLib/MfgToolLib.cpp
+++ b/Apps/MfgToolLib/MfgToolLib.cpp
@@ -56,6 +56,7 @@
 
 #include <algorithm>
 #include <map>
+#include <stdexcept>  // std::out_of_range
 #include <tuple>
 //#include "..\MfgTool.exe\gitversion.h"
 #include "UpdateUIInfo.h"
@@ -1323,7 +1324,7 @@ DWORD ParseUclXml(MFGLIB_VARS *pLibVars)
 
 		strTemp = (*it)->GetAttrValue(_T("body"));
 		strTemp = ReplaceKeywords(strTemp);
-		pOpCmd->SetBodyString(strTemp);
+		pOpCmd->SetTemplateBodyString(strTemp);
 		pOpCmd->SetDescString((*it)->GetText());
 
 		strTemp = (*it)->GetAttrValue(_T("ifdev"));
@@ -1434,15 +1435,34 @@ COpCommand::~COpCommand()
 {
 }
 
-void COpCommand::SetBodyString(CString &str)
+void COpCommand::SetBodyString(int index, const CString &str)
 {
-	m_bodyString = str;
+	m_bodyStringMap[index] = str;
 }
 
-CString COpCommand::GetBodyString()
+void COpCommand::SetTemplateBodyString(const CString &str)
 {
-	return m_bodyString;
+	m_templateBodyString = str;
 }
+
+CString COpCommand::GetBodyString(int index) const
+{
+	try
+	{
+		return m_bodyStringMap.at(index);
+	}
+	catch (const std::out_of_range& oor)
+	{
+		LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_FATAL_ERROR, _T("%s-- index %d not found in m_bodyString."), __func__, index);
+		return m_templateBodyString;
+	}
+}
+
+CString COpCommand::GetTemplateBodyString() const
+{
+	return m_templateBodyString;
+}
+
 
 void COpCommand::SetDescString(CString &str)
 {
@@ -1615,7 +1635,7 @@ UINT COpCmd_Boot::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -1632,7 +1652,7 @@ UINT COpCmd_Boot::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -1654,7 +1674,7 @@ UINT COpCmd_Boot::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -1682,7 +1702,7 @@ UINT COpCmd_Boot::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Boot\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -1787,7 +1807,7 @@ UINT COpCmd_Init::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Init\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Init\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -1804,7 +1824,7 @@ UINT COpCmd_Init::ExecuteCommand(int index)
 			_uiInfo.CommandStatus = COMMAND_STATUS_EXECUTE_ERROR;
 			_uiInfo.bUpdateDescription = TRUE;
 			CString strDesc;
-			strDesc.Format(_T("\"Init\" body=\"%s\" error, file=\"%s\""), GetBodyString(), m_FileName);
+			strDesc.Format(_T("\"Init\" body=\"%s\" error, file=\"%s\""), GetBodyString(index), m_FileName);
 			_tcscpy(_uiInfo.strDescription, strDesc.GetBuffer());
 			strDesc.ReleaseBuffer();
 			((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
@@ -2144,9 +2164,9 @@ UINT COpCmd_Push::ExecuteCommand(int index)
 {
 	CString strMsg;
 	if (m_FileName.IsEmpty())
-		strMsg.Format(_T("ExecuteCommand--Push[WndIndex:%d], Body is %s"), index, m_bodyString);
+		strMsg.Format(_T("ExecuteCommand--Push[WndIndex:%d], Body is %s"), index, GetBodyString(index));
 	else
-		strMsg.Format(_T("ExecuteCommand--Push[WndIndex:%d], Body is %s, File is %s"), index, m_bodyString, m_FileName);
+		strMsg.Format(_T("ExecuteCommand--Push[WndIndex:%d], Body is %s, File is %s"), index, GetBodyString(index), m_FileName);
 
 	LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_NORMAL_MSG, _T("%s"), strMsg);
 
@@ -2164,7 +2184,7 @@ UINT COpCmd_Push::ExecuteCommand(int index)
 	strDesc.ReleaseBuffer();
 	((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
 
-	CString csCmdBody = GetBodyString();
+	CString csCmdBody = GetBodyString(index);
 	CString csCmdText = GetDescString();
 	DWORD retValue = MFGLIB_ERROR_SUCCESS;
 
@@ -2429,7 +2449,7 @@ void COpCmd_Blhost::CloseFileMapping()
 UINT COpCmd_Blhost::ExecuteCommand(int index)
 {
 	CString strMsg;
-	strMsg.Format(_T("ExecuteCommand--Blhost[WndIndex:%d], Body is %s"), index, m_bodyString);
+	strMsg.Format(_T("ExecuteCommand--Blhost[WndIndex:%d], Body is %s"), index, GetBodyString(index));
 	LogMsg(LOG_MODULE_MFGTOOL_LIB, LOG_LEVEL_NORMAL_MSG, _T("%s"), strMsg);
 
 	UI_UPDATE_INFORMATION _uiInfo;
@@ -2446,7 +2466,7 @@ UINT COpCmd_Blhost::ExecuteCommand(int index)
 	strDesc.ReleaseBuffer();
 	((MFGLIB_VARS *)m_pLibVars)->g_CmdOperationArray[index]->ExecuteUIUpdate(&_uiInfo);
 
-	CString csCmdBody = GetBodyString();
+	CString csCmdBody = GetBodyString(index);
 	CString csCmdText = GetDescString();
 
 	if (csCmdText.CompareNoCase(_T("Done")) == 0)
@@ -3306,7 +3326,7 @@ void ReplaceAllUsbPortKeyWords(MFGLIB_VARS *pLibVars, int WndIndex)
 		{
 			for (auto& it : stateIt.second)
 			{
-				it->SetBodyString(ReplaceUsbPortKeywords(it->GetBodyString(), hub, port));
+				it->SetBodyString(WndIndex, ReplaceUsbPortKeywords(it->GetTemplateBodyString(), hub, port));
 			}
 		}
 	}

--- a/Apps/MfgToolLib/MfgToolLib.def
+++ b/Apps/MfgToolLib/MfgToolLib.def
@@ -24,3 +24,4 @@ EXPORTS
     MfgLib_DestoryInstanceHandle         @18
     MfgLib_SetUCLKeyWord                 @19
     MfgLib_SetUsbPortKeyWord             @20
+    MfgLib_SetCommandTimeout             @21

--- a/Apps/MfgToolLib/MfgToolLib.h
+++ b/Apps/MfgToolLib/MfgToolLib.h
@@ -168,8 +168,10 @@ public:
 	COpCommand();
 	virtual ~COpCommand();
 	virtual UINT ExecuteCommand(int index);
-	virtual void SetBodyString(CString &str);
-	virtual CString GetBodyString();
+	virtual void SetBodyString(int index, const CString &str);
+	virtual void SetTemplateBodyString(const CString &str);
+	virtual CString GetBodyString(int index) const;
+	virtual CString GetTemplateBodyString() const;
 	virtual void SetDescString(CString &str);
 	virtual CString GetDescString();
 	virtual void SetIfDevString(CString &str);
@@ -179,7 +181,8 @@ public:
 	INSTANCE_HANDLE m_pLibVars;
 
 protected:
-	CString m_bodyString;
+	std::map<int, CString> m_bodyStringMap;
+	CString m_templateBodyString;
 	CString m_descString;
 	CString m_ifdev;
 	CString m_ifhab;

--- a/Apps/MfgToolLib/MfgToolLib.h
+++ b/Apps/MfgToolLib/MfgToolLib.h
@@ -168,6 +168,7 @@ public:
 	COpCommand();
 	virtual ~COpCommand();
 	virtual UINT ExecuteCommand(int index);
+	virtual UINT ExecuteCommandWithTimeout(int index, DWORD timeout = INFINITE);
 	virtual void SetBodyString(int index, const CString &str);
 	virtual void SetTemplateBodyString(const CString &str);
 	virtual CString GetBodyString(int index) const;
@@ -178,6 +179,9 @@ public:
 	virtual void SetIfHabString(CString &str);
 	virtual bool IsRun(CString &dev);
 	virtual bool IsRun(HAB_t habState);
+	static void SetCommandTimeout(DWORD timeout) { m_commandTimeout = timeout; }
+	static DWORD GetCommandTimeout() { return m_commandTimeout; }
+
 	INSTANCE_HANDLE m_pLibVars;
 
 protected:
@@ -186,6 +190,7 @@ protected:
 	CString m_descString;
 	CString m_ifdev;
 	CString m_ifhab;
+	static DWORD m_commandTimeout;
 };
 
 class COpCmd_Find : public COpCommand

--- a/Apps/MfgToolLib/MfgToolLib_Export.h
+++ b/Apps/MfgToolLib/MfgToolLib_Export.h
@@ -229,6 +229,7 @@ DWORD MfgLib_UnregisterCallbackFunction(INSTANCE_HANDLE handle, CALLBACK_TYPE cb
 DWORD MfgLib_GetLibraryVersion(BYTE_t* version, int maxSize);
 DWORD MfgLib_SetUCLKeyWord(CHAR_t *key, CHAR_t *value);
 DWORD MfgLib_SetUsbPortKeyWord(UINT hub, UINT index, CHAR_t *key, CHAR_t *value);
+DWORD MfgLib_SetCommandTimeout(DWORD timeout);
 
 
 

--- a/Apps/MfgTool_MultiPanel/MfgTool_MultiPanel.cpp
+++ b/Apps/MfgTool_MultiPanel/MfgTool_MultiPanel.cpp
@@ -382,6 +382,10 @@ BOOL CMfgTool_MultiPanelApp::InitInstance()
 					}
 				}
 			}
+			else if ((strParamType.CompareNoCase(_T("-t")) == 0)) // timeout in minutes before considering a command FAILED. By default INFINITE
+			{
+				MfgLib_SetCommandTimeout(_ttoll(szArglist[i + 1]));
+			}
 		}
 		LocalFree(szArglist);
 	}
@@ -795,6 +799,18 @@ BOOL CMfgTool_MultiPanelApp::ParseMyCommandLine(CString strCmdLine)
 				strParameters = strParameters.Right(strParameters.GetLength()-i);
 				strParameters.TrimLeft();
 			}
+		}
+		else if (strParamType.CompareNoCase(_T("-t")) == 0)
+		{
+			for (i = 1; i<strParameters.GetLength(); i++)
+			{
+				if (strParameters.GetAt(i) == chSpace)
+				{
+					break;
+				}
+			}
+			strParameters = strParameters.Right(strParameters.GetLength() - i);
+			strParameters.TrimLeft();
 		}
 		else if( strParamType.CompareNoCase(_T("-noui"))==0 )
 		{


### PR DESCRIPTION
In console mode:
	- add the possibility to specify via -t a timeout in minutes
	before considering the command as failed
	- when a command is not executed within timeout, mark the whole
	download as failed
	- by default (i.e. if not specified via -t), timeout = INFINITE

Signed-off by: Paolo La Camera <paolo@airtame.com>