### PR TITLE
Add timeout management for each command in console mode

### DIFF
--- a/Apps/MfgToolLib/CmdOperation.cpp
+++ b/Apps/MfgToolLib/CmdOperation.cpp
@@ -551,7 +551,7 @@ UINT CmdListThreadProc(LPVOID pParam)
 				COpCommand *pCmd = (*cmdIt);
 				if(pCmd->IsRun(chip) && pCmd->IsRun(habstate))
 				{
-					dwError = pCmd->ExecuteCommand(pOperation->m_WndIndex);
+					dwError = pCmd->ExecuteCommandWithTimeout(pOperation->m_WndIndex, COpCommand::GetCommandTimeout());
 				}else
 				{
 					dwError = MFGLIB_ERROR_SKIP;

--- a/Apps/MfgToolLib/MfgToolLib.def
+++ b/Apps/MfgToolLib/MfgToolLib.def
@@ -24,3 +24,4 @@ EXPORTS
     MfgLib_DestoryInstanceHandle         @18
     MfgLib_SetUCLKeyWord                 @19
     MfgLib_SetUsbPortKeyWord             @20
+    MfgLib_SetCommandTimeout             @21

--- a/Apps/MfgToolLib/MfgToolLib.h
+++ b/Apps/MfgToolLib/MfgToolLib.h
@@ -168,6 +168,7 @@ public:
 	COpCommand();
 	virtual ~COpCommand();
 	virtual UINT ExecuteCommand(int index);
+	virtual UINT ExecuteCommandWithTimeout(int index, DWORD timeout = INFINITE);
 	virtual void SetBodyString(int index, const CString &str);
 	virtual void SetTemplateBodyString(const CString &str);
 	virtual CString GetBodyString(int index) const;
@@ -178,6 +179,9 @@ public:
 	virtual void SetIfHabString(CString &str);
 	virtual bool IsRun(CString &dev);
 	virtual bool IsRun(HAB_t habState);
+	static void SetCommandTimeout(DWORD timeout) { m_commandTimeout = timeout; }
+	static DWORD GetCommandTimeout() { return m_commandTimeout; }
+
 	INSTANCE_HANDLE m_pLibVars;
 
 protected:
@@ -186,6 +190,7 @@ protected:
 	CString m_descString;
 	CString m_ifdev;
 	CString m_ifhab;
+	static DWORD m_commandTimeout;
 };
 
 class COpCmd_Find : public COpCommand

--- a/Apps/MfgToolLib/MfgToolLib_Export.h
+++ b/Apps/MfgToolLib/MfgToolLib_Export.h
@@ -229,6 +229,7 @@ DWORD MfgLib_UnregisterCallbackFunction(INSTANCE_HANDLE handle, CALLBACK_TYPE cb
 DWORD MfgLib_GetLibraryVersion(BYTE_t* version, int maxSize);
 DWORD MfgLib_SetUCLKeyWord(CHAR_t *key, CHAR_t *value);
 DWORD MfgLib_SetUsbPortKeyWord(UINT hub, UINT index, CHAR_t *key, CHAR_t *value);
+DWORD MfgLib_SetCommandTimeout(DWORD timeout);
 
 
 

--- a/Apps/MfgTool_MultiPanel/MfgTool_MultiPanel.cpp
+++ b/Apps/MfgTool_MultiPanel/MfgTool_MultiPanel.cpp
@@ -382,6 +382,10 @@ BOOL CMfgTool_MultiPanelApp::InitInstance()
 					}
 				}
 			}
+			else if ((strParamType.CompareNoCase(_T("-t")) == 0)) // timeout in minutes before considering a command FAILED. By default INFINITE
+			{
+				MfgLib_SetCommandTimeout(_ttoll(szArglist[i + 1]));
+			}
 		}
 		LocalFree(szArglist);
 	}
@@ -795,6 +799,18 @@ BOOL CMfgTool_MultiPanelApp::ParseMyCommandLine(CString strCmdLine)
 				strParameters = strParameters.Right(strParameters.GetLength()-i);
 				strParameters.TrimLeft();
 			}
+		}
+		else if (strParamType.CompareNoCase(_T("-t")) == 0)
+		{
+			for (i = 1; i<strParameters.GetLength(); i++)
+			{
+				if (strParameters.GetAt(i) == chSpace)
+				{
+					break;
+				}
+			}
+			strParameters = strParameters.Right(strParameters.GetLength() - i);
+			strParameters.TrimLeft();
 		}
 		else if( strParamType.CompareNoCase(_T("-noui"))==0 )
 		{


### PR DESCRIPTION
In console mode:
	- add the possibility to specify via -t a timeout in minutes
	before considering the command as failed. By default (if not
	specified), timeout is INFINITE
	- when a command is not executed within timeout, mark the whole
	download for the device as failed.

Signed-off-by: Paolo La Camera <paolo@airtame.com>